### PR TITLE
Display the 10th char on main frame tab

### DIFF
--- a/components/account/Worlds/World4/Mainframe.js
+++ b/components/account/Worlds/World4/Mainframe.js
@@ -9,7 +9,7 @@ const Mainframe = ({ characters, jewels, labBonuses, playersCords }) => {
     <>
       <Stack my={4} direction={'row'} flexWrap={'wrap'} justifyContent={'center'} gap={2}>
         {playersCords?.map((playerCord, index) => {
-          if (index > 8) return null;
+          if (index > 9) return null;
           const playerName = characters?.[index]?.name;
           const classIndex = characters?.[index]?.classIndex;
           const isUploaded = characters?.[index]?.afkTarget === 'Laboratory';


### PR DESCRIPTION
10th char wasn't displayed on the main frame tab char list. Not sure if the check is needed at all?

Also, the line widths (and connections) aren't also calculated correctly for me. The local version seems to display a bit different numbers than idleontoolbox.com so maybe there are some unpushed fixes already?