### PR TITLE
Worship page error with no skull equped

### DIFF
--- a/pages/account/world-3/worship.js
+++ b/pages/account/world-3/worship.js
@@ -25,9 +25,9 @@ const Worship = () => {
               <CardContent>
                 <Stack direction={'row'}>
                   <img src={`${prefix}data/ClassIcons${classIndex}.png`} alt=''/>
-                  <Tooltip title={cleanUnderscore(skull.name)}>
+                  {skull &&<Tooltip title={cleanUnderscore(skull.name)}>
                     <img style={{ height: 38 }} src={`${prefix}data/${skull.rawName}.png`} alt=''/>
-                  </Tooltip>
+                  </Tooltip>}
                 </Stack>
                 <Typography sx={{ typography: { xs: "body2", sm: "body1" } }}>{name}</Typography>
                 <Typography variant={'caption'}>Worship


### PR DESCRIPTION
Fixed a bug where the worship page won't render when a skull isn't equipped