### PR TITLE
Fix trades date increasing

### DIFF
--- a/utility/helpers.js
+++ b/utility/helpers.js
@@ -28,7 +28,7 @@ export const eventsColors = {
 }
 export const getClosestDate = (date, hours = 0, every) => {
   // Get the current date
-  const currentDate = date;
+  const currentDate = new Date(date.getTime());
 
 // Add 6 hours to the current date
   currentDate.setHours(currentDate.getHours() + hours);


### PR DESCRIPTION
Fix trades dates.

The gap between the trades was increasing exponentially.
It was caused by js copying the reference and not the value of a date in the method getClosestDate