### PR TITLE
feat: Add bubble name to bubbles page cards

### DIFF
--- a/pages/account/world-2/bubbles.js
+++ b/pages/account/world-2/bubbles.js
@@ -253,6 +253,10 @@ const Bubbles = () => {
               }}>
                 <CardContent>
                   <Stack direction={'row'} alignItems={'center'} justifyContent={'space-around'} gap={2}>
+                  <Typography
+                        variant={'body1'}>{cleanUnderscore(bubbleName)}</Typography>
+                  </Stack>
+                  <Stack direction={'row'} alignItems={'center'} justifyContent={'space-around'} gap={2}>
                     <Stack alignItems={'center'}>
                       <HtmlTooltip title={<BubbleTooltip {...{ ...bubble, goalLevel }}/>}>
                         <BubbleIcon width={48} height={48}


### PR DESCRIPTION
Adds the bubble name to the cards on the alchemy bubbles page. 
Tested on Mobile view and web view. 

![image](https://github.com/Morta1/IdleonToolbox/assets/8051409/9d147f3b-decb-4420-8104-bdc2fb23feaf)

![image](https://github.com/Morta1/IdleonToolbox/assets/8051409/354bd8e4-546a-411e-a170-6dd789cbf21c)
