### PR TITLE
fix(lab): round player coordinates

### DIFF
--- a/components/account/Worlds/World4/Mainframe.js
+++ b/components/account/Worlds/World4/Mainframe.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Card, CardContent, Stack, Typography } from '@mui/material';
-import { cleanUnderscore, prefix } from 'utility/helpers';
+import { cleanUnderscore, prefix, round } from 'utility/helpers';
 import styled from '@emotion/styled';
 import Tooltip from 'components/Tooltip';
 import { isGodEnabledBySorcerer } from '../../../../parsers/lab';
@@ -30,7 +30,7 @@ const Mainframe = ({ characters, jewels, labBonuses, playersCords, divinity }) =
                   <Stack>
                     <Typography>{playerName}</Typography>
                     <Typography>{playerCord?.lineWidth}px</Typography>
-                    <Typography variant={'caption'}>({playerCord.x},{playerCord.y})</Typography>
+                    <Typography variant={'caption'}>({round(playerCord.x)},{round(playerCord.y)})</Typography>
                   </Stack>
                   {/*<img src={`${prefix}data/head.png`} alt={''}/>*/}
                 </Stack>


### PR DESCRIPTION
The lab coordinates are not rounded, this results in very long decimals. It is possible that you can't see the second coordinate because of the decimals of the first.

Previous situation:
![image](https://github.com/Morta1/IdleonToolbox/assets/76728727/85e899bd-403a-4de2-b4d9-a4ec74962987)


After this PR:
![image](https://github.com/Morta1/IdleonToolbox/assets/76728727/00fe684e-c973-46fa-8315-702b5e6322a1)
