### PR TITLE
Fix "Closest salt" timer to account for time away

### DIFF
--- a/components/dashboard/Etc.jsx
+++ b/components/dashboard/Etc.jsx
@@ -260,15 +260,15 @@ const Etc = ({ characters, account, lastUpdated, trackers }) => {
           lastUpdated={lastUpdated} time={nextPrinterCycle} icon={'data/ConTower0.png'}/> : null}
         {trackers?.['World 3']?.closestTrap?.checked && account?.finishedWorlds?.World2 && closestTrap !== 0 ? <TimerCard
             page={'account/world-3/traps'}
-            tooltipContent={'Closest trap: ' + getRealDateInMs(closestTrap)}
-            lastUpdated={lastUpdated} time={closestTrap} icon={'data/TrapBoxSet1.png'}/>
+            tooltipContent={'Closest trap: ' + getRealDateInMs(account?.timeAway?.GlobalTime * 1000 - new Date().getTime() + closestTrap)}
+            lastUpdated={lastUpdated} time={account?.timeAway?.GlobalTime * 1000 - new Date().getTime() + closestTrap} icon={'data/TrapBoxSet1.png'}/>
           : null}
         {trackers?.['World 3']?.closestBuilding?.checked && account?.finishedWorlds?.World2 && closestBuilding?.timeLeft !== 0
           ?
           <TimerCard
             page={'account/world-3/buildings'}
-            tooltipContent={'Closest building: ' + getRealDateInMs(new Date().getTime() + closestBuilding?.timeLeft)}
-            lastUpdated={lastUpdated} time={new Date().getTime() + closestBuilding?.timeLeft}
+            tooltipContent={'Closest building: ' + getRealDateInMs(account?.timeAway?.GlobalTime * 1000 + closestBuilding?.timeLeft)}
+            lastUpdated={lastUpdated} time={account?.timeAway?.GlobalTime * 1000 + closestBuilding?.timeLeft}
             icon={`data/${closestBuilding?.icon}.png`}/>
           : null}
         {trackers?.['World 3']?.closestSalt?.checked && account?.finishedWorlds?.World2 && closestSalt?.timeLeft !== 0 ?

--- a/parsers/refinery.js
+++ b/parsers/refinery.js
@@ -185,7 +185,7 @@ export const calcTimeToRankUp = (account, characters, lastUpdated, refineryData,
   const timeLeft = ((powerCap - refined) / powerPerCycle) / combustionCyclesPerDay * 24 / (labCycleBonus);
   const totalTime = ((powerCap - 0) / powerPerCycle) / combustionCyclesPerDay * 24 / (labCycleBonus);
   return {
-    timeLeft: new Date().getTime() + (timeLeft * 3600 * 1000),
+    timeLeft: new Date().getTime() + (timeLeft * 3600 * 1000) - account?.timeAway?.GlobalTime,
     totalTime: new Date().getTime() + (totalTime * 3600 * 1000)
   };
 };

--- a/parsers/refinery.js
+++ b/parsers/refinery.js
@@ -185,7 +185,7 @@ export const calcTimeToRankUp = (account, characters, lastUpdated, refineryData,
   const timeLeft = ((powerCap - refined) / powerPerCycle) / combustionCyclesPerDay * 24 / (labCycleBonus);
   const totalTime = ((powerCap - 0) / powerPerCycle) / combustionCyclesPerDay * 24 / (labCycleBonus);
   return {
-    timeLeft: new Date().getTime() + (timeLeft * 3600 * 1000) - account?.timeAway?.GlobalTime,
+    timeLeft: (account?.timeAway?.GlobalTime * 1000) + (timeLeft * 3600 * 1000),
     totalTime: new Date().getTime() + (totalTime * 3600 * 1000)
   };
 };


### PR DESCRIPTION
I apologize that I'm not actually familiar with Javascript, but I noticed a bug where the "Closest salt" timer resets on page reload without reflecting the elapsed time. Submitting this PR probably just to point out the bug and give my best guess at what the fix would be.