### PR TITLE
fix(emperor): prevent doubling when two bonuses share a name

### DIFF
--- a/parsers/world-6/emperor.ts
+++ b/parsers/world-6/emperor.ts
@@ -28,15 +28,16 @@ export const getEmperor = (idleonData: any, account: any) => {
       self.findIndex(t => t.name === val.name && t.index === val.index) === idx
   );
   const totalBonuses: Record<string, any> = emperorBonuses.reduce((result: Record<string, any>, bonus, index) => {
-    if (!result[bonus.name]) {
-      result[bonus.name] = 0;
+    const key = `${bonus.name}|${bonus.index}`;
+    if (!result[key]) {
+      result[key] = 0;
     }
     if (index < highestEmperorShowdown) {
       const cycles = Math.floor(highestEmperorShowdown / 48);
       const effectiveIndex = highestEmperorShowdown % 48;
-      result[bonus.name] += (bonus?.value ?? 0) * cycles;
+      result[key] += (bonus?.value ?? 0) * cycles;
       if (index < effectiveIndex) {
-        result[bonus.name] += bonus?.value ?? 0;
+        result[key] += bonus?.value ?? 0;
       }
       return result;
     } else {
@@ -51,7 +52,7 @@ export const getEmperor = (idleonData: any, account: any) => {
     .replace('}', '' + notateNumber(1 + total / 100, 'MultiplierInfo'))
     .replace('$', '' + Math.floor((total + 4) / (total + 100) * 1000) / 10);
   bonuses = bonuses.map((rawBonus) => {
-    const baseTotal = totalBonuses[rawBonus.name] ?? 0;
+    const baseTotal = totalBonuses[`${rawBonus.name}|${rawBonus.index}`] ?? 0;
     const realTotal = Math.floor(baseTotal * multiTotal);
     const bonus = formatBonusName(rawBonus.name, realTotal);
     const baseBonus = formatBonusName(rawBonus.name, baseTotal);


### PR DESCRIPTION
## Summary
- Two emperor bonuses can share the same display name but have distinct `index` values (currently the two World 7ish bonuses at indexes 9 and 10).
- `bonuses` correctly dedups by name+index, but `totalBonuses` was keyed by `name` only — so both contributions accumulated in one bucket and both cards rendered the doubled total (e.g. +39% / +20% base instead of +19% / +10% base).
- Key `totalBonuses` by `name|index` and look it up the same way when mapping bonuses.

## Test plan
- [ ] Showdown ≥ 132: each World 7ish card shows the per-bonus total (e.g. +19% with arcade multi), not the combined sum
- [ ] Other bonuses (unique names) still show correct totals
- [ ] `getEmperorBonus(account, index)` consumers unchanged (still keyed by `rawIndex`)