### PR TITLE
feat(research): show real Insight/hr alongside displayed value

### DIFF
--- a/components/account/Worlds/World7/Research/Observations.jsx
+++ b/components/account/Worlds/World7/Research/Observations.jsx
@@ -110,8 +110,20 @@ const Observations = ({ observations }) => {
                       </Typography>
                     </Stack>
                     <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
-                      <Typography variant="body2" color="text.secondary">Insight / hr:</Typography>
+                      <Tooltip title="Insight EXP/hr as shown in-game (Insight rate * Research EXP Multi). This is what Idleon displays, but does NOT match how fast Insight actually levels up.">
+                        <Typography variant="body2" color="text.secondary" sx={{ textDecoration: 'underline dotted', cursor: 'help' }}>
+                          Displayed Insight / hr:
+                        </Typography>
+                      </Tooltip>
                       <Typography variant="body2">{notateNumber(obs.insightExpRate ?? 0, 'Small')}</Typography>
+                    </Stack>
+                    <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
+                      <Tooltip title="Actual Insight EXP/hr you gain (Displayed / Research EXP Multi). This matches how fast Insight levels up in practice.">
+                        <Typography variant="body2" color="text.secondary" sx={{ textDecoration: 'underline dotted', cursor: 'help' }}>
+                          Real Insight / hr:
+                        </Typography>
+                      </Tooltip>
+                      <Typography variant="body2">{notateNumber(obs.realInsightExpRate ?? 0, 'Small')}</Typography>
                     </Stack>
                     <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
                       <Typography variant="body2" color="text.secondary">Research EXP rate:</Typography>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/parsers/world-7/research.ts
+++ b/parsers/world-7/research.ts
@@ -187,7 +187,8 @@ export const getResearch = (idleonData: any, account: any, characters: any) => {
     const insightLevel = Number(research?.observationInsight?.[observationIndex]) || 0;
     const insightExp = Number(research?.observationInsightExp?.[observationIndex]) || 0;
     const insightExpREQ = getObservationInsightExpREQ(observationIndex, insightLevel);
-    const insightExpRate = getObservationInsightExpRate(account, research, observationIndex) * researchEXPmulti;
+    const realInsightExpRate = getObservationInsightExpRate(account, research, observationIndex);
+    const insightExpRate = realInsightExpRate * researchEXPmulti;
     const researchEXPrate = getResearchEXPrateObj(account, research, observationIndex) * researchEXPmulti;
     const occurrenceData = occurrencesList[observationIndex];
     // Lenses on this observation: type 0 = Magnifying glass, 1 = Kaleidoscope, 2 = Optical Monocle
@@ -218,6 +219,7 @@ export const getResearch = (idleonData: any, account: any, characters: any) => {
       insightExp,
       insightExpREQ,
       insightExpRate,
+      realInsightExpRate,
       researchEXPrate,
       lensTypes, // 0 = Magnifying glass, 1 = Kaleidoscope, 2 = Optical Monocle
       canLevelUp: found && researchLevel >= (occurrenceData?.researchLvReq ?? 0) && gridBonus91Lv >= 1


### PR DESCRIPTION
Displayed Insight/hr (Insight rate * Research EXP Multi) matches in-game text but does not reflect how fast Insight actually levels. Add Real Insight/hr (without the multi) so users can see the true rate, with tooltips explaining the difference.